### PR TITLE
[flutter_local_notifications]Update gson package for vulnerabilities

### DIFF
--- a/flutter_local_notifications/android/build.gradle
+++ b/flutter_local_notifications/android/build.gradle
@@ -36,6 +36,6 @@ android {
 dependencies {
     implementation "androidx.core:core:1.3.0"
     implementation "androidx.media:media:1.1.0"
-    implementation "com.google.code.gson:gson:2.8.6"
+    implementation "com.google.code.gson:gson:2.8.9"
     implementation "com.jakewharton.threetenabp:threetenabp:1.2.3"
 }


### PR DESCRIPTION
Fixes CVE-2022-25647.

This updates an android jar to a version without the vulnerability. Vulnerability is considered HIGH and more info is [here](https://nvd.nist.gov/vuln/detail/CVE-2022-25647#range-7910512)
